### PR TITLE
Fix building with gcc15 installed via conda

### DIFF
--- a/pyclass/negnuclass/patch/Makefile
+++ b/pyclass/negnuclass/patch/Makefile
@@ -22,7 +22,7 @@ vpath .base build
 # LDFLAG=-lomp
 
 # your C compiler:
-CC ?= gcc -std=gnu17
+CC ?= gcc
 #CC = icc
 #CC = pgcc
 
@@ -46,7 +46,7 @@ OMPFLAG ?= -fopenmp
 #OMPFLAG   = -mp -mp=nonuma -mp=allcores -g
 #OMPFLAG   = -openmp
 
-CCFLAG ?= -fPIC
+CCFLAG ?= -fPIC -std=gnu17
 LDFLAG ?= -fPIC
 
 # all other compilation flags


### PR DESCRIPTION
https://github.com/adematti/pyclass/pull/6#issuecomment-3776857087

conda will override `CC` if gcc>=15 is installed via conda